### PR TITLE
libsupport: Fix build on gcc 11.2

### DIFF
--- a/libs/libsupport/KeyMap.h
+++ b/libs/libsupport/KeyMap.h
@@ -64,7 +64,7 @@ KeyMap<KEY, TYPE>::ValueFor(KEY k, bool* found) const
 	}
 
 	if (i == fMap.end())
-		return NULL;
+		return 0;
 	return i->second;
 }
 


### PR DESCRIPTION
Fixes build on gcc 11.2...


```
libs/libsupport/KeyMap.h: In instantiation of 'TYPE KeyMap<KEY, TYPE>::ValueFor(KEY, bool*) const [with KEY = BString; TYPE = int]':
protocols/purple/PurpleApp.cpp:561:45:   required from here
libs/libsupport/KeyMap.h:67:24: error: cannot convert 'std::nullptr_t' to 'int' in return
   67 |                 return NULL;
      |                        ^~~~
/boot/system/develop//etc/makefile-engine:300: recipe for target 'objects.x86_64-cc11-release/PurpleApp.o' failed
```